### PR TITLE
[ADHOC] Review Restructure

### DIFF
--- a/leafwheels/pom.xml
+++ b/leafwheels/pom.xml
@@ -93,6 +93,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/bootstrap/VehicleHistoryLoader.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/bootstrap/VehicleHistoryLoader.java
@@ -36,9 +36,6 @@ public class VehicleHistoryLoader implements CommandLineRunner {
         List<Vehicle> vehicles = vehicleRepository.findAll();
 
         if (vehicles.size() >= 20) {
-            // Only USED vehicles (high mileage) get accident history
-            // New vehicles (mileage < 300km) will have NO history
-            
             // Vehicle 2: Nissan Leaf (USED - 15000km) - 1 accident
             Vehicle nissanLeaf = vehicles.get(1);
             vehicleHistoryRepository.save(
@@ -89,8 +86,6 @@ public class VehicleHistoryLoader implements CommandLineRunner {
                             .build()
             );
 
-            // NOTE: Vehicles 1, 3, 5, 7, 8, 10 (first 10) have no accident history
-            // ALL NEW vehicles (11-20) have NO accident history
         }
     }
 }

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/config/CorsConfig.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/config/CorsConfig.java
@@ -7,11 +7,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**") // Apply to all paths
-                .allowedOrigins("http://localhost:5173") // Specify allowed origins
-                .allowedMethods("*") //
-                .allowedHeaders("*") // Allow all headers
-                .allowCredentials(true); // Allow sending of cookies and authentication headers
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }
 

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/domain/Review.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/domain/Review.java
@@ -1,15 +1,17 @@
 package com.yorku4413s25.leafwheels.domain;
 
-import com.yorku4413s25.leafwheels.constants.ItemType;
+import com.yorku4413s25.leafwheels.constants.Make;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.util.UUID;
 
 @Entity
-@Table(name = "reviews")
+@Table(name = "reviews", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"userId", "make", "model"}))
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -20,22 +22,26 @@ public class Review extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID reviewId;
 
+    @NotNull(message = "User ID is required")
     @Column(nullable = false)
     private UUID userId;
 
-    @Column(nullable = false)
-    private UUID vehicleId;
+    @NotNull(message = "Make is required")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private Make make;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "vehicleId", insertable = false, updatable = false)
-    private Vehicle vehicle;
+    @NotNull(message = "Model is required")
+    @Column(nullable = false, length = 100)
+    private String model;
 
     @Column(length = 500)
     private String comment;
 
-    @Column(nullable = false)
+    @NotNull(message = "Rating is required")
     @Min(value = 1, message = "Rating must be between 1 and 5")
     @Max(value = 5, message = "Rating must be between 1 and 5")
+    @Column(nullable = false)
     private int rating;
 
 

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/domain/Vehicle.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/domain/Vehicle.java
@@ -98,17 +98,14 @@ public class Vehicle extends BaseEntity{
 
     public void updateDiscountCalculations() {
         if (this.price != null) {
-            // Calculate based on discountAmount first
             if (this.discountAmount != null && this.discountAmount.compareTo(BigDecimal.ZERO) > 0) {
                 this.discountPrice = this.price.subtract(this.discountAmount);
                 this.onDeal = true;
             }
-            // Calculate based on discountPercentage if no discountAmount
             else if (this.discountPercentage != null && this.discountPercentage.compareTo(BigDecimal.ZERO) > 0) {
                 this.discountPrice = this.price.multiply(BigDecimal.ONE.subtract(this.discountPercentage));
                 this.onDeal = true;
             }
-            // No discount
             else {
                 this.discountPrice = this.price;
                 this.onDeal = false;

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/domain/Vehicle.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/domain/Vehicle.java
@@ -8,9 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 @Entity
@@ -97,20 +95,6 @@ public class Vehicle extends BaseEntity{
     @OneToMany(mappedBy = "vehicle", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<VehicleHistory> vehicleHistories;
 
-    @OneToMany(mappedBy = "vehicle", fetch = FetchType.LAZY)
-    private List<Review> reviews;
-
-    @Column(precision = 3, scale = 1)
-    private BigDecimal averageRating = BigDecimal.ZERO;
-
-    @Column
-    private int totalReviews = 0;
-
-    @ElementCollection
-    @CollectionTable(name = "vehicle_star_ratings", joinColumns = @JoinColumn(name = "vehicle_id"))
-    @MapKeyColumn(name = "star_rating")
-    @Column(name = "count")
-    private Map<Integer, Integer> starRatingCounts = new HashMap<>();
 
     public void updateDiscountCalculations() {
         if (this.price != null) {

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/exception/ApplicationExceptionHandler.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/exception/ApplicationExceptionHandler.java
@@ -43,6 +43,12 @@ public class ApplicationExceptionHandler extends ResponseEntityExceptionHandler 
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
+        ErrorResponse error = new ErrorResponse(Arrays.asList(ex.getMessage()));
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
                                                                   HttpHeaders headers, HttpStatusCode status,

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/repositories/ReviewRepository.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/repositories/ReviewRepository.java
@@ -3,6 +3,8 @@ package com.yorku4413s25.leafwheels.repositories;
 import com.yorku4413s25.leafwheels.constants.Make;
 import com.yorku4413s25.leafwheels.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +15,10 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     List<Review> findByUserId(UUID userId);
     List<Review> findByMakeAndModel(Make make, String model);
     boolean existsByUserIdAndMakeAndModel(UUID userId, Make make, String model);
+    
+    @Query("SELECT r FROM Review r WHERE r.make = :make AND LOWER(r.model) = LOWER(:model)")
+    List<Review> findByMakeAndModelIgnoreCase(@Param("make") Make make, @Param("model") String model);
+    
+    @Query("SELECT COUNT(r) > 0 FROM Review r WHERE r.userId = :userId AND r.make = :make AND LOWER(r.model) = LOWER(:model)")
+    boolean existsByUserIdAndMakeAndModelIgnoreCase(@Param("userId") UUID userId, @Param("make") Make make, @Param("model") String model);
 }

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/repositories/ReviewRepository.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/repositories/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.yorku4413s25.leafwheels.repositories;
 
+import com.yorku4413s25.leafwheels.constants.Make;
 import com.yorku4413s25.leafwheels.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,6 @@ import java.util.UUID;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
     List<Review> findByUserId(UUID userId);
-    List<Review> findByVehicleId(UUID vehicleId);
+    List<Review> findByMakeAndModel(Make make, String model);
+    boolean existsByUserIdAndMakeAndModel(UUID userId, Make make, String model);
 }

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/OrderServiceImpl.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/OrderServiceImpl.java
@@ -40,7 +40,6 @@ public class OrderServiceImpl implements OrderService {
         if (dto.getItems() == null || dto.getItems().isEmpty())
             throw new IllegalArgumentException("Order must have at least one item");
 
-        // Build OrderItems and calculate total
         List<OrderItem> orderItems = new ArrayList<>();
         BigDecimal total = BigDecimal.ZERO;
 
@@ -56,9 +55,7 @@ public class OrderServiceImpl implements OrderService {
                         .orElseThrow(() -> new EntityNotFoundException(itemDto.getVehicleId(), Vehicle.class));
                 itemBuilder.vehicle(vehicle).accessory(null);
                 itemBuilder.unitPrice(vehicle.getPrice());
-                itemBuilder.quantity(1); // Only 1 vehicle per orderItem
-                // Optionally mark vehicle as sold here or after payment
-                // vehicle.setStatus(VehicleStatus.SOLD);
+                itemBuilder.quantity(1);
                 total = total.add(vehicle.getPrice());
             } else if (itemDto.getType() == ItemType.ACCESSORY) {
                 if (itemDto.getAccessoryId() == null)

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/ReviewService.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/ReviewService.java
@@ -1,6 +1,8 @@
 package com.yorku4413s25.leafwheels.services;
 
+import com.yorku4413s25.leafwheels.constants.Make;
 import com.yorku4413s25.leafwheels.web.models.ReviewDto;
+import com.yorku4413s25.leafwheels.web.models.ReviewSummaryDto;
 
 import java.util.List;
 import java.util.UUID;
@@ -9,6 +11,7 @@ public interface ReviewService {
     ReviewDto createReview(ReviewDto reviewDto);
     List<ReviewDto> getAllReviews();
     List<ReviewDto> getReviewsByUserId(UUID userId);
-    List<ReviewDto> getReviewsByVehicleId(UUID vehicleId);
+    List<ReviewDto> getReviewsByMakeAndModel(Make make, String model);
+    ReviewSummaryDto getReviewSummary(Make make, String model);
     void deleteReview(UUID reviewId);
 }

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/ReviewServiceImpl.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/ReviewServiceImpl.java
@@ -26,7 +26,7 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public ReviewDto createReview(ReviewDto reviewDto) {
-        if (reviewRepository.existsByUserIdAndMakeAndModel(
+        if (reviewRepository.existsByUserIdAndMakeAndModelIgnoreCase(
                 reviewDto.getUserId(), reviewDto.getMake(), reviewDto.getModel())) {
             throw new IllegalArgumentException("User has already reviewed this make/model combination");
         }
@@ -55,7 +55,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     @Transactional(readOnly = true)
     public List<ReviewDto> getReviewsByMakeAndModel(Make make, String model) {
-        return reviewRepository.findByMakeAndModel(make, model).stream()
+        return reviewRepository.findByMakeAndModelIgnoreCase(make, model).stream()
                 .map(reviewMapper::reviewToReviewDto)
                 .collect(Collectors.toList());
     }
@@ -63,7 +63,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     @Transactional(readOnly = true)
     public ReviewSummaryDto getReviewSummary(Make make, String model) {
-        List<Review> reviews = reviewRepository.findByMakeAndModel(make, model);
+        List<Review> reviews = reviewRepository.findByMakeAndModelIgnoreCase(make, model);
         
         if (reviews.isEmpty()) {
             return ReviewSummaryDto.builder()

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/ReviewServiceImpl.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/ReviewServiceImpl.java
@@ -1,16 +1,19 @@
 package com.yorku4413s25.leafwheels.services;
 
+import com.yorku4413s25.leafwheels.constants.Make;
 import com.yorku4413s25.leafwheels.domain.Review;
 import com.yorku4413s25.leafwheels.exception.EntityNotFoundException;
 import com.yorku4413s25.leafwheels.repositories.ReviewRepository;
 import com.yorku4413s25.leafwheels.web.mappers.ReviewMapper;
 import com.yorku4413s25.leafwheels.web.models.ReviewDto;
+import com.yorku4413s25.leafwheels.web.models.ReviewSummaryDto;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.UUID;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @AllArgsConstructor
@@ -20,13 +23,16 @@ public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ReviewMapper reviewMapper;
-    private final VehicleService vehicleService;
 
     @Override
     public ReviewDto createReview(ReviewDto reviewDto) {
+        if (reviewRepository.existsByUserIdAndMakeAndModel(
+                reviewDto.getUserId(), reviewDto.getMake(), reviewDto.getModel())) {
+            throw new IllegalArgumentException("User has already reviewed this make/model combination");
+        }
+        
         Review review = reviewMapper.reviewDtoToReview(reviewDto);
         Review saved = reviewRepository.save(review);
-        vehicleService.updateVehicleRatings(reviewDto.getVehicleId());
         return reviewMapper.reviewToReviewDto(saved);
     }
 
@@ -48,10 +54,36 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ReviewDto> getReviewsByVehicleId(UUID vehicleId) {
-        return reviewRepository.findByVehicleId(vehicleId).stream()
+    public List<ReviewDto> getReviewsByMakeAndModel(Make make, String model) {
+        return reviewRepository.findByMakeAndModel(make, model).stream()
                 .map(reviewMapper::reviewToReviewDto)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReviewSummaryDto getReviewSummary(Make make, String model) {
+        List<Review> reviews = reviewRepository.findByMakeAndModel(make, model);
+        
+        if (reviews.isEmpty()) {
+            return ReviewSummaryDto.builder()
+                    .make(make)
+                    .model(model)
+                    .averageRating(BigDecimal.ZERO)
+                    .totalReviews(0)
+                    .starRatingCounts(initializeStarCounts())
+                    .individualReviews(List.of())
+                    .build();
+        }
+        
+        return ReviewSummaryDto.builder()
+                .make(make)
+                .model(model)
+                .averageRating(calculateAverageRating(reviews))
+                .totalReviews(reviews.size())
+                .starRatingCounts(calculateStarRatingCounts(reviews))
+                .individualReviews(mapToReviewDtos(reviews))
+                .build();
     }
 
     @Override
@@ -59,10 +91,40 @@ public class ReviewServiceImpl implements ReviewService {
         if (!reviewRepository.existsById(reviewId)) {
             throw new EntityNotFoundException(reviewId, Review.class);
         }
-        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> 
-            new EntityNotFoundException(reviewId, Review.class));
-        UUID vehicleId = review.getVehicle().getId();
         reviewRepository.deleteById(reviewId);
-        vehicleService.updateVehicleRatings(vehicleId);
+    }
+    
+    private BigDecimal calculateAverageRating(List<Review> reviews) {
+        double average = reviews.stream()
+                .mapToInt(Review::getRating)
+                .average()
+                .orElse(0.0);
+        return BigDecimal.valueOf(average)
+                .setScale(1, RoundingMode.HALF_UP);
+    }
+    
+    private Map<Integer, Integer> calculateStarRatingCounts(List<Review> reviews) {
+        Map<Integer, Integer> counts = initializeStarCounts();
+        
+        reviews.stream()
+                .collect(Collectors.groupingBy(Review::getRating, Collectors.counting()))
+                .forEach((rating, count) -> counts.put(rating, count.intValue()));
+                
+        return counts;
+    }
+    
+    private Map<Integer, Integer> initializeStarCounts() {
+        Map<Integer, Integer> counts = new HashMap<>();
+        for (int i = 1; i <= 5; i++) {
+            counts.put(i, 0);
+        }
+        return counts;
+    }
+    
+    private List<ReviewDto> mapToReviewDtos(List<Review> reviews) {
+        return reviews.stream()
+                .map(reviewMapper::reviewToReviewDto)
+                .sorted((r1, r2) -> r2.getCreatedAt().compareTo(r1.getCreatedAt())) // Sort by newest first
+                .collect(Collectors.toList());
     }
 }

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/VehicleService.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/VehicleService.java
@@ -4,7 +4,6 @@ import com.yorku4413s25.leafwheels.constants.BodyType;
 import com.yorku4413s25.leafwheels.constants.Condition;
 import com.yorku4413s25.leafwheels.constants.Make;
 import com.yorku4413s25.leafwheels.constants.VehicleStatus;
-import com.yorku4413s25.leafwheels.domain.Vehicle;
 import com.yorku4413s25.leafwheels.web.models.VehicleDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -52,6 +51,4 @@ public interface VehicleService {
     List<VehicleDto> getAvailableVehicles();
 
     VehicleDto addImageUrls(UUID vehicleId, List<String> imageUrls);
-
-    void updateVehicleRatings(UUID vehicleId);
 }

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/VehicleServiceImpl.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/services/VehicleServiceImpl.java
@@ -8,8 +8,6 @@ import com.yorku4413s25.leafwheels.domain.Vehicle;
 import com.yorku4413s25.leafwheels.domain.VehicleSpecification;
 import com.yorku4413s25.leafwheels.exception.EntityNotFoundException;
 import com.yorku4413s25.leafwheels.repositories.VehicleRepository;
-import com.yorku4413s25.leafwheels.repositories.ReviewRepository;
-import com.yorku4413s25.leafwheels.web.mappers.DateMapper;
 import com.yorku4413s25.leafwheels.web.mappers.VehicleMapper;
 import com.yorku4413s25.leafwheels.web.models.VehicleDto;
 import lombok.AllArgsConstructor;
@@ -20,13 +18,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.StreamSupport;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -38,7 +32,6 @@ public class VehicleServiceImpl implements VehicleService {
 
     private final VehicleRepository vehicleRepository;
     private final VehicleMapper vehicleMapper;
-    private final ReviewRepository reviewRepository;
 
     @Override
     public VehicleDto getById(UUID vehicleId) {
@@ -170,42 +163,6 @@ public class VehicleServiceImpl implements VehicleService {
         return vehicleMapper.vehicleToVehicleDto(vehicleRepository.save(vehicle));
     }
 
-    @Override
-    @Transactional
-    public void updateVehicleRatings(UUID vehicleId) {
-        Vehicle vehicle = vehicleRepository.findById(vehicleId)
-                .orElseThrow(() -> new EntityNotFoundException(vehicleId, Vehicle.class));
-        
-        var reviews = reviewRepository.findByVehicleId(vehicleId);
-        
-        if (reviews.isEmpty()) {
-            vehicle.setAverageRating(BigDecimal.ZERO);
-            vehicle.setTotalReviews(0);
-            vehicle.setStarRatingCounts(new HashMap<>());
-        } else {
-            double average = reviews.stream()
-                    .mapToInt(review -> review.getRating())
-                    .average()
-                    .orElse(0.0);
-            vehicle.setAverageRating(BigDecimal.valueOf(average).setScale(1, RoundingMode.HALF_UP));
-
-            vehicle.setTotalReviews(reviews.size());
-
-            Map<Integer, Integer> starCounts = new HashMap<>();
-            for (int i = 1; i <= 5; i++) {
-                starCounts.put(i, 0);
-            }
-            
-            reviews.forEach(review -> {
-                int rating = review.getRating();
-                starCounts.put(rating, starCounts.get(rating) + 1);
-            });
-            
-            vehicle.setStarRatingCounts(starCounts);
-        }
-        
-        vehicleRepository.save(vehicle);
-    }
 
     private <T> void addIfNotNull(List<Specification<Vehicle>> specs, T value, Function<T, Specification<Vehicle>> fn) {
         if (value != null) {

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/controllers/ReviewController.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/controllers/ReviewController.java
@@ -64,8 +64,13 @@ public class ReviewController {
                     content = @Content(schema = @Schema(implementation = ReviewDto.class)))
     })
     @GetMapping("/make/{make}/model/{model}")
-    public ResponseEntity<List<ReviewDto>> getByMakeAndModel(@PathVariable Make make, @PathVariable String model) {
-        return ResponseEntity.ok(reviewService.getReviewsByMakeAndModel(make, model));
+    public ResponseEntity<List<ReviewDto>> getByMakeAndModel(@PathVariable String make, @PathVariable String model) {
+        try {
+            Make makeEnum = Make.valueOf(make.toUpperCase());
+            return ResponseEntity.ok(reviewService.getReviewsByMakeAndModel(makeEnum, model));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid make: " + make);
+        }
     }
 
     @Operation(summary = "Get review summary", description = "Retrieve comprehensive review summary for a make and model including average rating, star distribution, and individual reviews.")
@@ -74,8 +79,13 @@ public class ReviewController {
                     content = @Content(schema = @Schema(implementation = ReviewSummaryDto.class)))
     })
     @GetMapping("/make/{make}/model/{model}/summary")
-    public ResponseEntity<ReviewSummaryDto> getReviewSummary(@PathVariable Make make, @PathVariable String model) {
-        return ResponseEntity.ok(reviewService.getReviewSummary(make, model));
+    public ResponseEntity<ReviewSummaryDto> getReviewSummary(@PathVariable String make, @PathVariable String model) {
+        try {
+            Make makeEnum = Make.valueOf(make.toUpperCase());
+            return ResponseEntity.ok(reviewService.getReviewSummary(makeEnum, model));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid make: " + make);
+        }
     }
 
     @Operation(summary = "Delete a review", description = "Remove a review by its ID.")

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/controllers/ReviewController.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/controllers/ReviewController.java
@@ -1,7 +1,9 @@
 package com.yorku4413s25.leafwheels.web.controllers;
 
+import com.yorku4413s25.leafwheels.constants.Make;
 import com.yorku4413s25.leafwheels.services.ReviewService;
 import com.yorku4413s25.leafwheels.web.models.ReviewDto;
+import com.yorku4413s25.leafwheels.web.models.ReviewSummaryDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,11 +27,11 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @Operation(summary = "Create a review", description = "Submit a new review for a vehicle by a user.")
+    @Operation(summary = "Create a review", description = "Submit a new review for a make and model by a user.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Review created",
                     content = @Content(schema = @Schema(implementation = ReviewDto.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content)
+            @ApiResponse(responseCode = "400", description = "Invalid input or duplicate review", content = @Content)
     })
     @PostMapping
     public ResponseEntity<ReviewDto> createReview(@Valid @RequestBody ReviewDto dto) {
@@ -56,15 +58,24 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.getReviewsByUserId(userId));
     }
 
-    @Operation(summary = "Get reviews by vehicle", description = "Retrieve all reviews for a specific vehicle.")
+    @Operation(summary = "Get reviews by make and model", description = "Retrieve all reviews for a specific make and model.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "List of vehicle reviews",
-                    content = @Content(schema = @Schema(implementation = ReviewDto.class))),
-            @ApiResponse(responseCode = "404", description = "Vehicle not found", content = @Content)
+            @ApiResponse(responseCode = "200", description = "List of reviews for make/model",
+                    content = @Content(schema = @Schema(implementation = ReviewDto.class)))
     })
-    @GetMapping("/vehicle/{vehicleId}")
-    public ResponseEntity<List<ReviewDto>> getByVehicle(@PathVariable UUID vehicleId) {
-        return ResponseEntity.ok(reviewService.getReviewsByVehicleId(vehicleId));
+    @GetMapping("/make/{make}/model/{model}")
+    public ResponseEntity<List<ReviewDto>> getByMakeAndModel(@PathVariable Make make, @PathVariable String model) {
+        return ResponseEntity.ok(reviewService.getReviewsByMakeAndModel(make, model));
+    }
+
+    @Operation(summary = "Get review summary", description = "Retrieve comprehensive review summary for a make and model including average rating, star distribution, and individual reviews.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Review summary for make/model",
+                    content = @Content(schema = @Schema(implementation = ReviewSummaryDto.class)))
+    })
+    @GetMapping("/make/{make}/model/{model}/summary")
+    public ResponseEntity<ReviewSummaryDto> getReviewSummary(@PathVariable Make make, @PathVariable String model) {
+        return ResponseEntity.ok(reviewService.getReviewSummary(make, model));
     }
 
     @Operation(summary = "Delete a review", description = "Remove a review by its ID.")

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/models/ReviewDto.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/models/ReviewDto.java
@@ -1,10 +1,11 @@
 package com.yorku4413s25.leafwheels.web.models;
+import com.yorku4413s25.leafwheels.constants.Make;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import java.util.UUID;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @NoArgsConstructor
@@ -12,18 +13,24 @@ import java.time.LocalDateTime;
 @Builder
 
 public class ReviewDto {
-    private UUID reviewId; //unique review ID
+    private UUID reviewId;
     
     @NotNull(message = "User ID is required")
-    private UUID userId; //user's connected id
+    private UUID userId;
     
-    @NotNull(message = "Vehicle ID is required")
-    private UUID vehicleId;
+    @NotNull(message = "Make is required")
+    private Make make;
+    
+    @NotNull(message = "Model is required")  
+    private String model;
     
     private String comment;
     
+    @NotNull(message = "Rating is required")
     @Min(value = 1, message = "Rating must be between 1 and 5")
     @Max(value = 5, message = "Rating must be between 1 and 5")
-    private int rating; // constrained to 1-5 stars
+    private int rating;
+    
+    private Instant createdAt;
 
 }

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/models/ReviewSummaryDto.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/models/ReviewSummaryDto.java
@@ -1,0 +1,21 @@
+package com.yorku4413s25.leafwheels.web.models;
+
+import com.yorku4413s25.leafwheels.constants.Make;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewSummaryDto {
+    private Make make; //vehicle make
+    private String model; //vehicle model
+    private BigDecimal averageRating; //average rating e.g. 4.2
+    private int totalReviews; //total number of reviews e.g. 47
+    private Map<Integer, Integer> starRatingCounts; //star distribution {5: 23, 4: 15, 3: 6, 2: 2, 1: 1}
+    private List<ReviewDto> individualReviews; //all individual reviews with comments and ratings
+}

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/models/ReviewSummaryDto.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/models/ReviewSummaryDto.java
@@ -12,10 +12,10 @@ import java.util.Map;
 @AllArgsConstructor
 @Builder
 public class ReviewSummaryDto {
-    private Make make; //vehicle make
-    private String model; //vehicle model
-    private BigDecimal averageRating; //average rating e.g. 4.2
-    private int totalReviews; //total number of reviews e.g. 47
-    private Map<Integer, Integer> starRatingCounts; //star distribution {5: 23, 4: 15, 3: 6, 2: 2, 1: 1}
-    private List<ReviewDto> individualReviews; //all individual reviews with comments and ratings
+    private Make make;
+    private String model;
+    private BigDecimal averageRating;
+    private int totalReviews;
+    private Map<Integer, Integer> starRatingCounts;
+    private List<ReviewDto> individualReviews;
 }

--- a/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/models/VehicleDto.java
+++ b/leafwheels/src/main/java/com/yorku4413s25/leafwheels/web/models/VehicleDto.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -82,14 +81,4 @@ public class VehicleDto implements Serializable {
     List<String> imageUrls;
 
     List<VehicleHistoryDto> vehicleHistories;
-
-    @Schema(description = "Average rating from all reviews (1-5 stars, 1 decimal place)", example = "4.2")
-    @JsonSerialize(using = ToStringSerializer.class)
-    BigDecimal averageRating;
-
-    @Schema(description = "Total number of reviews for this vehicle", example = "15")
-    int totalReviews;
-
-    @Schema(description = "Count of reviews for each star rating (1-5)", example = "{\"1\": 0, \"2\": 1, \"3\": 2, \"4\": 5, \"5\": 7}")
-    Map<Integer, Integer> starRatingCounts;
 }

--- a/leafwheels/src/test/java/com/yorku4413s25/leafwheels/web/controllers/ReviewControllerTest.java
+++ b/leafwheels/src/test/java/com/yorku4413s25/leafwheels/web/controllers/ReviewControllerTest.java
@@ -1,0 +1,418 @@
+package com.yorku4413s25.leafwheels.web.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.yorku4413s25.leafwheels.constants.Make;
+import com.yorku4413s25.leafwheels.domain.Review;
+import com.yorku4413s25.leafwheels.exception.ApplicationExceptionHandler;
+import com.yorku4413s25.leafwheels.exception.EntityNotFoundException;
+import com.yorku4413s25.leafwheels.services.ReviewService;
+import com.yorku4413s25.leafwheels.web.models.ReviewDto;
+import com.yorku4413s25.leafwheels.web.models.ReviewSummaryDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class ReviewControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ReviewService reviewService;
+
+    private ReviewController reviewController;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        reviewController = new ReviewController(reviewService);
+        mockMvc = MockMvcBuilders.standaloneSetup(reviewController)
+                .setControllerAdvice(new ApplicationExceptionHandler())
+                .build();
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    // ===== CRUD OPERATION TESTS =====
+
+    @Test
+    void createReviewShouldReturnCreatedReviewWhenValidInput() throws Exception {
+        ReviewDto inputDto = createSampleReviewDto();
+        inputDto.setReviewId(null); // Input should not have ID
+        
+        ReviewDto createdDto = createSampleReviewDto();
+        createdDto.setReviewId(UUID.randomUUID()); // Service returns with ID
+        createdDto.setCreatedAt(Instant.now());
+
+        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto);
+
+        mockMvc.perform(post("/api/v1/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.reviewId").value(createdDto.getReviewId().toString()))
+                .andExpect(jsonPath("$.userId").value(createdDto.getUserId().toString()))
+                .andExpect(jsonPath("$.make").value("TESLA"))
+                .andExpect(jsonPath("$.model").value("Model 3"))
+                .andExpect(jsonPath("$.rating").value(5))
+                .andExpect(jsonPath("$.comment").value("Excellent electric vehicle!"));
+
+        verify(reviewService).createReview(any(ReviewDto.class));
+    }
+
+    @Test
+    void getAllReviewsShouldReturnListOfReviews() throws Exception {
+        List<ReviewDto> reviews = Arrays.asList(
+                createSampleReviewDto(),
+                createAnotherSampleReviewDto()
+        );
+
+        when(reviewService.getAllReviews()).thenReturn(reviews);
+
+        mockMvc.perform(get("/api/v1/reviews"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].rating").value(5))
+                .andExpect(jsonPath("$[1].rating").value(3));
+
+        verify(reviewService).getAllReviews();
+    }
+
+    @Test
+    void getReviewsByUserShouldReturnUserReviews() throws Exception {
+        UUID userId = UUID.randomUUID();
+        List<ReviewDto> userReviews = Arrays.asList(createSampleReviewDto());
+
+        when(reviewService.getReviewsByUserId(userId)).thenReturn(userReviews);
+
+        mockMvc.perform(get("/api/v1/reviews/user/{userId}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].userId").value(userReviews.get(0).getUserId().toString()));
+
+        verify(reviewService).getReviewsByUserId(userId);
+    }
+
+    @Test
+    void getReviewsByMakeAndModelShouldReturnMakeModelReviews() throws Exception {
+        Make make = Make.TESLA;
+        String model = "Model 3";
+        List<ReviewDto> makeModelReviews = Arrays.asList(
+                createSampleReviewDto(),
+                createAnotherSampleReviewDto()
+        );
+
+        when(reviewService.getReviewsByMakeAndModel(make, model)).thenReturn(makeModelReviews);
+
+        mockMvc.perform(get("/api/v1/reviews/make/{make}/model/{model}", make, model))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].make").value("TESLA"))
+                .andExpect(jsonPath("$[0].model").value("Model 3"));
+
+        verify(reviewService).getReviewsByMakeAndModel(make, model);
+    }
+
+    @Test
+    void getReviewSummaryShouldReturnComprehensiveReviewData() throws Exception {
+        Make make = Make.TESLA;
+        String model = "Model 3";
+        ReviewSummaryDto summaryDto = createSampleReviewSummaryDto();
+
+        when(reviewService.getReviewSummary(make, model)).thenReturn(summaryDto);
+
+        mockMvc.perform(get("/api/v1/reviews/make/{make}/model/{model}/summary", make, model))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.make").value("TESLA"))
+                .andExpect(jsonPath("$.model").value("Model 3"))
+                .andExpect(jsonPath("$.averageRating").value(4.2))
+                .andExpect(jsonPath("$.totalReviews").value(5))
+                .andExpect(jsonPath("$.starRatingCounts.5").value(2))
+                .andExpect(jsonPath("$.starRatingCounts.4").value(2))
+                .andExpect(jsonPath("$.starRatingCounts.3").value(1))
+                .andExpect(jsonPath("$.individualReviews.length()").value(2));
+
+        verify(reviewService).getReviewSummary(make, model);
+    }
+
+    @Test
+    void deleteReviewShouldReturnNoContentWhenReviewExists() throws Exception {
+        UUID reviewId = UUID.randomUUID();
+
+        doNothing().when(reviewService).deleteReview(reviewId);
+
+        mockMvc.perform(delete("/api/v1/reviews/{reviewId}", reviewId))
+                .andExpect(status().isNoContent());
+
+        verify(reviewService).deleteReview(reviewId);
+    }
+
+    // ===== BUSINESS LOGIC TESTS =====
+
+    @Test
+    void createReviewShouldReturn400WhenDuplicateReview() throws Exception {
+        ReviewDto inputDto = createSampleReviewDto();
+        inputDto.setReviewId(null);
+
+        when(reviewService.createReview(any(ReviewDto.class)))
+                .thenThrow(new IllegalArgumentException("User has already reviewed this make/model combination"));
+
+        mockMvc.perform(post("/api/v1/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto)))
+                .andExpect(status().isBadRequest()); // IllegalArgumentException now handled as 400
+
+        verify(reviewService).createReview(any(ReviewDto.class));
+    }
+
+    @Test
+    void createReviewShouldPassWithoutValidation() throws Exception {
+        // NOTE: Without validation framework, these tests verify controller behavior
+        // In a real application, you would add spring-boot-starter-validation dependency
+        
+        ReviewDto inputDto = createSampleReviewDto();
+        inputDto.setRating(0); // Would be invalid with validation
+        inputDto.setReviewId(null);
+        
+        ReviewDto createdDto = createSampleReviewDto();
+        createdDto.setRating(0);
+        createdDto.setReviewId(UUID.randomUUID());
+        createdDto.setCreatedAt(Instant.now());
+
+        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto);
+
+        mockMvc.perform(post("/api/v1/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.rating").value(0));
+
+        verify(reviewService).createReview(any(ReviewDto.class));
+    }
+
+    @Test
+    void createReviewShouldAcceptNullFields() throws Exception {
+        // NOTE: Without validation framework, null fields are accepted
+        ReviewDto inputDto = createSampleReviewDto();
+        inputDto.setUserId(null);
+        inputDto.setMake(null);
+        inputDto.setModel(null);
+        inputDto.setReviewId(null);
+        
+        ReviewDto createdDto = createSampleReviewDto();
+        createdDto.setUserId(null);
+        createdDto.setMake(null);
+        createdDto.setModel(null);
+        createdDto.setReviewId(UUID.randomUUID());
+        createdDto.setCreatedAt(Instant.now());
+
+        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto);
+
+        mockMvc.perform(post("/api/v1/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto)))
+                .andExpect(status().isCreated());
+
+        verify(reviewService).createReview(any(ReviewDto.class));
+    }
+
+    @Test
+    void createReviewShouldAcceptValidRatingBoundaries() throws Exception {
+        // Test rating = 1
+        ReviewDto inputDto1 = createSampleReviewDto();
+        inputDto1.setRating(1);
+        inputDto1.setReviewId(null);
+        
+        ReviewDto createdDto1 = createSampleReviewDto();
+        createdDto1.setRating(1);
+        createdDto1.setReviewId(UUID.randomUUID());
+        createdDto1.setCreatedAt(Instant.now());
+
+        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto1);
+
+        mockMvc.perform(post("/api/v1/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto1)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.rating").value(1));
+
+        // Test rating = 5
+        ReviewDto inputDto5 = createSampleReviewDto();
+        inputDto5.setRating(5);
+        inputDto5.setReviewId(null);
+        
+        ReviewDto createdDto5 = createSampleReviewDto();
+        createdDto5.setRating(5);
+        createdDto5.setReviewId(UUID.randomUUID());
+        createdDto5.setCreatedAt(Instant.now());
+
+        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto5);
+
+        mockMvc.perform(post("/api/v1/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto5)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.rating").value(5));
+
+        verify(reviewService, times(2)).createReview(any(ReviewDto.class));
+    }
+
+    @Test
+    void createReviewShouldAcceptNullComment() throws Exception {
+        ReviewDto inputDto = createSampleReviewDto();
+        inputDto.setComment(null); // Comment is optional
+        inputDto.setReviewId(null);
+        
+        ReviewDto createdDto = createSampleReviewDto();
+        createdDto.setComment(null);
+        createdDto.setReviewId(UUID.randomUUID());
+        createdDto.setCreatedAt(Instant.now());
+
+        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto);
+
+        mockMvc.perform(post("/api/v1/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.comment").doesNotExist());
+
+        verify(reviewService).createReview(any(ReviewDto.class));
+    }
+
+    @Test
+    void deleteReviewShouldReturn404WhenReviewNotFound() throws Exception {
+        UUID reviewId = UUID.randomUUID();
+
+        doThrow(new EntityNotFoundException(reviewId, Review.class)).when(reviewService).deleteReview(reviewId);
+
+        mockMvc.perform(delete("/api/v1/reviews/{reviewId}", reviewId))
+                .andExpect(status().isNotFound());
+
+        verify(reviewService).deleteReview(reviewId);
+    }
+
+    @Test
+    void getReviewSummaryShouldReturnEmptyWhenNoReviews() throws Exception {
+        Make make = Make.TESLA;
+        String model = "Model 3";
+        ReviewSummaryDto emptyDto = ReviewSummaryDto.builder()
+                .make(make)
+                .model(model)
+                .averageRating(BigDecimal.ZERO)
+                .totalReviews(0)
+                .starRatingCounts(createEmptyStarCounts())
+                .individualReviews(Arrays.asList())
+                .build();
+
+        when(reviewService.getReviewSummary(make, model)).thenReturn(emptyDto);
+
+        mockMvc.perform(get("/api/v1/reviews/make/{make}/model/{model}/summary", make, model))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.averageRating").value(0))
+                .andExpect(jsonPath("$.totalReviews").value(0))
+                .andExpect(jsonPath("$.individualReviews.length()").value(0));
+
+        verify(reviewService).getReviewSummary(make, model);
+    }
+
+    @Test
+    void createReviewShouldHandleLongComment() throws Exception {
+        ReviewDto inputDto = createSampleReviewDto();
+        inputDto.setComment("This is a very long comment that tests the character limit functionality. " +
+                "The system should handle longer comments gracefully within the database constraints. " +
+                "This particular comment is designed to test how the system handles realistic user feedback " +
+                "that might be more detailed than typical short reviews. Users often want to provide comprehensive " +
+                "feedback about their experience with electric vehicles, including details about performance, " +
+                "charging experience, build quality, and overall satisfaction.");
+        inputDto.setReviewId(null);
+        
+        ReviewDto createdDto = createSampleReviewDto();
+        createdDto.setComment(inputDto.getComment());
+        createdDto.setReviewId(UUID.randomUUID());
+        createdDto.setCreatedAt(Instant.now());
+
+        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto);
+
+        mockMvc.perform(post("/api/v1/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.comment").value(inputDto.getComment()));
+
+        verify(reviewService).createReview(any(ReviewDto.class));
+    }
+
+    // ===== HELPER METHODS =====
+
+    private ReviewDto createSampleReviewDto() {
+        return ReviewDto.builder()
+                .reviewId(UUID.randomUUID())
+                .userId(UUID.randomUUID())
+                .make(Make.TESLA)
+                .model("Model 3")
+                .rating(5)
+                .comment("Excellent electric vehicle!")
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    private ReviewDto createAnotherSampleReviewDto() {
+        return ReviewDto.builder()
+                .reviewId(UUID.randomUUID())
+                .userId(UUID.randomUUID())
+                .make(Make.TESLA)
+                .model("Model 3")
+                .rating(3)
+                .comment("Average performance, could be better.")
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    private ReviewSummaryDto createSampleReviewSummaryDto() {
+        Map<Integer, Integer> starCounts = new HashMap<>();
+        starCounts.put(1, 0);
+        starCounts.put(2, 0);
+        starCounts.put(3, 1);
+        starCounts.put(4, 2);
+        starCounts.put(5, 2);
+
+        return ReviewSummaryDto.builder()
+                .make(Make.TESLA)
+                .model("Model 3")
+                .averageRating(BigDecimal.valueOf(4.2))
+                .totalReviews(5)
+                .starRatingCounts(starCounts)
+                .individualReviews(Arrays.asList(
+                        createSampleReviewDto(),
+                        createAnotherSampleReviewDto()
+                ))
+                .build();
+    }
+
+    private Map<Integer, Integer> createEmptyStarCounts() {
+        Map<Integer, Integer> starCounts = new HashMap<>();
+        for (int i = 1; i <= 5; i++) {
+            starCounts.put(i, 0);
+        }
+        return starCounts;
+    }
+}

--- a/leafwheels/src/test/java/com/yorku4413s25/leafwheels/web/controllers/ReviewControllerTest.java
+++ b/leafwheels/src/test/java/com/yorku4413s25/leafwheels/web/controllers/ReviewControllerTest.java
@@ -185,54 +185,36 @@ class ReviewControllerTest {
     }
 
     @Test
-    void createReviewShouldPassWithoutValidation() throws Exception {
-        // NOTE: Without validation framework, these tests verify controller behavior
-        // In a real application, you would add spring-boot-starter-validation dependency
+    void createReviewShouldRejectInvalidRating() throws Exception {
+        // With validation framework active, invalid ratings should be rejected
         
         ReviewDto inputDto = createSampleReviewDto();
-        inputDto.setRating(0); // Would be invalid with validation
+        inputDto.setRating(0); // Invalid rating (must be 1-5)
         inputDto.setReviewId(null);
-        
-        ReviewDto createdDto = createSampleReviewDto();
-        createdDto.setRating(0);
-        createdDto.setReviewId(UUID.randomUUID());
-        createdDto.setCreatedAt(Instant.now());
-
-        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto);
 
         mockMvc.perform(post("/api/v1/reviews")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(inputDto)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.rating").value(0));
+                .andExpect(status().isBadRequest());
 
-        verify(reviewService).createReview(any(ReviewDto.class));
+        verify(reviewService, never()).createReview(any(ReviewDto.class));
     }
 
     @Test
-    void createReviewShouldAcceptNullFields() throws Exception {
-        // NOTE: Without validation framework, null fields are accepted
+    void createReviewShouldRejectNullRequiredFields() throws Exception {
+        // With validation framework active, null required fields should be rejected
         ReviewDto inputDto = createSampleReviewDto();
-        inputDto.setUserId(null);
-        inputDto.setMake(null);
-        inputDto.setModel(null);
+        inputDto.setUserId(null); // Required field
+        inputDto.setMake(null); // Required field
+        inputDto.setModel(null); // Required field
         inputDto.setReviewId(null);
-        
-        ReviewDto createdDto = createSampleReviewDto();
-        createdDto.setUserId(null);
-        createdDto.setMake(null);
-        createdDto.setModel(null);
-        createdDto.setReviewId(UUID.randomUUID());
-        createdDto.setCreatedAt(Instant.now());
-
-        when(reviewService.createReview(any(ReviewDto.class))).thenReturn(createdDto);
 
         mockMvc.perform(post("/api/v1/reviews")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(inputDto)))
-                .andExpect(status().isCreated());
+                .andExpect(status().isBadRequest());
 
-        verify(reviewService).createReview(any(ReviewDto.class));
+        verify(reviewService, never()).createReview(any(ReviewDto.class));
     }
 
     @Test


### PR DESCRIPTION
Changes made:

1. Review Entity Restructure:
 * Removed vehicleId and Vehicle relationship
 * Added make (Make enum) and model (String) fields
 * Added unique constraint: one review per user per make/model
 * Added proper validation annotations

  
2. Enhanced Review DTOs:
 * Updated ReviewDto with make/model fields
 * Created ReviewSummaryDto with rich display features:
 * Average rating calculation
 * Star rating distribution (1-5 star counts)
 * Individual reviews with comments

  
3. Advanced Review Service:
 * Duplicate review prevention logic
 * Comprehensive rating calculations (average, distribution)
 * Make/model based querying
 * Sorted individual reviews (newest first)

  
4. New API Endpoints:
 * GET /api/v1/reviews/make/{make}/model/{model} - Get reviews for make/model
 * GET /api/v1/reviews/make/{make}/model/{model}/summary - Rich summary with stats
 * POST /api/v1/reviews - Create review (now with make/model validation)